### PR TITLE
Vanilla Tweaks Compatibility for Grindstone and Client-side Rendering

### DIFF
--- a/src/client/java/dorkix/armored/elytra/RenderHelper.java
+++ b/src/client/java/dorkix/armored/elytra/RenderHelper.java
@@ -4,10 +4,12 @@ import java.util.Optional;
 
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.BundleContentsComponent;
 import net.minecraft.component.type.NbtComponent;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.nbt.NbtCompound;
+import net.minecraft.registry.tag.ItemTags;
 
 public class RenderHelper {
 
@@ -15,6 +17,16 @@ public class RenderHelper {
     var player = MinecraftClient.getInstance().player;
     if (!stack.isOf(Items.ELYTRA) || player == null)
       return stack;
+    
+    // Vanilla Tweaks compatibility
+    BundleContentsComponent bundleContents = stack.getOrDefault(DataComponentTypes.BUNDLE_CONTENTS, BundleContentsComponent.DEFAULT);
+    if (!bundleContents.isEmpty()) {
+      for (ItemStack item : bundleContents.iterate()) {
+        if (item.isIn(ItemTags.CHEST_ARMOR)) {
+            return item;
+        }
+      }
+    }
 
     // get the saved chestplate ItemStack as nbt
     Optional<NbtCompound> chestplateDataNbt = stack.getOrDefault(DataComponentTypes.CUSTOM_DATA, NbtComponent.DEFAULT)
@@ -43,6 +55,16 @@ public class RenderHelper {
     var player = MinecraftClient.getInstance().player;
     if (!stack.isOf(Items.ELYTRA) || player == null)
       return stack;
+    
+    // Vanilla Tweaks compatibility
+    BundleContentsComponent bundleContents = stack.getOrDefault(DataComponentTypes.BUNDLE_CONTENTS, BundleContentsComponent.DEFAULT);
+    if (!bundleContents.isEmpty()) {
+      for (ItemStack item : bundleContents.iterate()) {
+        if (item.isOf(Items.ELYTRA)) {
+            return item;
+        }
+      }
+    }
 
     // get the saved elytra ItemStack as nbt
     Optional<NbtCompound> elytraDataNbt = stack.getOrDefault(DataComponentTypes.CUSTOM_DATA, NbtComponent.DEFAULT)

--- a/src/main/java/dorkix/armored/elytra/mixin/GrindStoneMixin.java
+++ b/src/main/java/dorkix/armored/elytra/mixin/GrindStoneMixin.java
@@ -12,6 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import dorkix.armored.elytra.ArmoredElytra;
 import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.BundleContentsComponent;
 import net.minecraft.component.type.NbtComponent;
 import net.minecraft.entity.ExperienceOrbEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -181,6 +182,28 @@ public abstract class GrindStoneMixin extends ScreenHandler {
             return true;
         }
 
+        // try split the elytra for the given slot (Vanilla Tweaks Format)
+        private boolean trySplitVTArmoredElytra(int slot) {
+            BundleContentsComponent bundleContents = ((GrindstoneScreenHandlerAccessor) field_16780)
+                    .getInput().getStack(slot).getOrDefault(DataComponentTypes.BUNDLE_CONTENTS,
+                            BundleContentsComponent.DEFAULT);
+            if (!bundleContents.isEmpty())
+                return false;
+
+            var context = ((GrindstoneScreenHandlerAccessor) field_16780).getContext();
+            bundleContents.iterate().forEach(item -> {
+                if (item.isOf(Items.ELYTRA)) {
+                    context.run((world, blockPos) -> {
+                        world.playSound(null, blockPos, SoundEvents.BLOCK_GRINDSTONE_USE,
+                                SoundCategory.BLOCKS);
+                        ((GrindstoneScreenHandlerAccessor) field_16780).getInput().setStack(slot,
+                                item);
+                    });
+                }
+            });
+            return true;
+        }
+
         // When the user takes out result chestplate from the
         // GrindStoneMixin.showSplitResult() try getting the source elytry from the
         // input slots, replace the armored elytra with the source elytra and cancel the
@@ -193,6 +216,8 @@ public abstract class GrindStoneMixin extends ScreenHandler {
                 CallbackInfo ci) {
 
             if (!trySplitArmoredElytra(0) && !trySplitArmoredElytra(1)) {
+                return;
+            } else if (!trySplitVTArmoredElytra(0) && !trySplitVTArmoredElytra(1)) {
                 return;
             }
 


### PR DESCRIPTION
This PR adds the ability to split Armored Elytra created with the Vanilla Tweaks datapack. Useful for people that were playing with the datapack and migrated to this mod.

It also makes the mod able to render VT-style armored elytra on the client.