### PR TITLE
Burn Elytra but save netherite chest in lava

### DIFF
--- a/src/main/java/dorkix/armored/elytra/ArmoredElytra.java
+++ b/src/main/java/dorkix/armored/elytra/ArmoredElytra.java
@@ -18,7 +18,6 @@ import net.minecraft.component.type.NbtComponent;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.nbt.NbtCompound;
-import net.minecraft.registry.tag.DamageTypeTags;
 import net.minecraft.registry.tag.ItemTags;
 import net.minecraft.screen.ScreenHandlerContext;
 import net.minecraft.text.Style;
@@ -77,14 +76,6 @@ public class ArmoredElytra implements ModInitializer {
 		if (trims != null && trims.isPresent()) {
 			newElytra.applyChanges(ComponentChanges.builder().add(DataComponentTypes.TRIM,
 					trims.get()).build());
-		}
-
-		// Copy Lava immunity
-		var fire_res = armor.get(DataComponentTypes.DAMAGE_RESISTANT);
-		if (fire_res != null && fire_res.types() == DamageTypeTags.IS_FIRE) {
-			newElytra.applyChanges(
-					ComponentChanges.builder().add(DataComponentTypes.DAMAGE_RESISTANT,
-							fire_res).build());
 		}
 
 		var armorType = armor.getItem().toString();

--- a/src/main/java/dorkix/armored/elytra/mixin/EntityLavaHurtMixin.java
+++ b/src/main/java/dorkix/armored/elytra/mixin/EntityLavaHurtMixin.java
@@ -1,0 +1,62 @@
+package dorkix.armored.elytra.mixin;
+
+import java.util.Optional;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import dorkix.armored.elytra.ArmoredElytra;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.BundleContentsComponent;
+import net.minecraft.component.type.NbtComponent;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.ItemEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.sound.SoundEvents;
+import net.minecraft.world.World;
+
+@Mixin(Entity.class)
+public abstract class EntityLavaHurtMixin  {
+    @Inject(method = "setOnFireFromLava", at = @At("TAIL"))
+    private void splitNetheriteInLava(CallbackInfo ci) {
+        if ((Entity) (Object) this instanceof ItemEntity) {
+            ItemEntity thisObject = (ItemEntity) (Object) this;
+
+            ItemStack itemStack = thisObject.getStack();
+            if (itemStack.isOf(Items.ELYTRA)) {
+                BundleContentsComponent bundleContents = itemStack.getOrDefault(
+                        DataComponentTypes.BUNDLE_CONTENTS, BundleContentsComponent.DEFAULT);
+                if (!bundleContents.isEmpty()) {
+                    // Handle Vanilla Tweaks data
+                    bundleContents.iterate().forEach(item -> {
+                        if (item.isOf(Items.NETHERITE_CHESTPLATE)) {
+                            thisObject.setStack(item);
+                        }
+                    });
+                } else {
+                    // Handle native mod data
+                    Optional<NbtCompound> armorDataNbt = itemStack
+                            .getOrDefault(DataComponentTypes.CUSTOM_DATA, NbtComponent.DEFAULT)
+                            .copyNbt().getCompound(ArmoredElytra.CHESTPLATE_DATA.toString());
+                    if (armorDataNbt.isEmpty())
+                        return;
+
+                    NbtCompound armorData = armorDataNbt.get();
+                    if (armorData.isEmpty())
+                        return;
+
+                    ItemStack chestplate =
+                            ItemStack.fromNbt(thisObject.getWorld().getRegistryManager(), armorData)
+                                    .orElse(ItemStack.EMPTY);
+                    ((ItemEntity) (Object) this).setStack(chestplate);
+                }
+                World world = thisObject.getWorld();
+                world.playSound((Entity) null, thisObject.getX(), thisObject.getY(),
+                        thisObject.getZ(), SoundEvents.ENTITY_GENERIC_BURN,
+                        thisObject.getSoundCategory(), 0.4F, 2.0F + thisObject.getRandom().nextFloat() * 0.4F);
+            }
+        }
+    }
+}

--- a/src/main/resources/armored-elytra.mixins.json
+++ b/src/main/resources/armored-elytra.mixins.json
@@ -4,6 +4,7 @@
   "compatibilityLevel": "JAVA_21",
   "mixins": [
     "AnvilMenuMixin",
+    "EntityLavaHurtMixin",
     "GrindStoneMixin",
     "GrindStoneMixin$GrindstoneScreenHandlerAccessor",
     "GrindStoneMixin$ResultSlotMixin"


### PR DESCRIPTION
This PR changes the behavior of the Netherite armored Elytra. The elytra burns, while keeping the netherite chest, instead of making the entire item immune to fire.

Maybe this should be a setting? It does complicate the code quite a bit.