### PR TITLE
Fix Elytra rendering on vanilla clients

### DIFF
--- a/src/main/java/dorkix/armored/elytra/ArmoredElytra.java
+++ b/src/main/java/dorkix/armored/elytra/ArmoredElytra.java
@@ -140,6 +140,7 @@ public class ArmoredElytra implements ModInitializer {
 		newElytra.applyComponentsFrom(
 				ComponentMap.builder().add(DataComponentTypes.CUSTOM_DATA, NbtComponent.of(customData)).build());
 
+		newElytra.set(DataComponentTypes.ITEM_MODEL, Identifier.of(Items.ELYTRA.toString()));
 		newElytra.set(DataComponentTypes.CUSTOM_MODEL_DATA, new CustomModelDataComponent(Collections.emptyList(),
 				Collections.emptyList(), List.of(armorType), Collections.emptyList()));
 


### PR DESCRIPTION
This PR fixes how elytra's render in vanilla clients. They'll see a plain Elytra instead of a missing texture. 

Note: This will only fix newly created merged armored elytra, old ones wills till show a mixing texture until they're separated and re-merged